### PR TITLE
Remove standard assets requirement and add WebGL build instructions

### DIFF
--- a/Assets/PlayerController.cs
+++ b/Assets/PlayerController.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerController : MonoBehaviour
+{
+    [SerializeField] Transform playerCamera = null;
+    
+    [SerializeField] float mouseSensitivity = 3.0f;
+    [SerializeField] float keyRotSensitivity = 3.0f;
+    [SerializeField] float joyRotSensitivity = 10.0f;
+    [SerializeField] float walkSpeed = 6.0f;
+    [SerializeField] float vertSpeed = 6.0f;
+    [SerializeField] float joyFlySpeed = 6.0f;
+    [SerializeField] float joyWalkSpeed = 3.0f;
+    
+    [SerializeField] bool lockCursor = true;
+    
+    float cameraPitch = 0.0f;
+    
+    CharacterController controller = null;
+    
+    void Start()
+    {
+        controller = GetComponent<CharacterController>();
+	
+        if(lockCursor)
+	{
+	    Cursor.lockState = CursorLockMode.Locked;
+	    Cursor.visible = false;
+	}
+    }
+
+    void Update()
+    {
+        UpdateSettings();
+        UpdateRotation();
+	UpdateMovement();
+    }
+    
+    void UpdateSettings()
+    {
+        if(Input.GetKey("escape"))
+	{
+	    Application.Quit();
+	}
+    }
+    
+    void UpdateRotation()
+    {
+    	float yaw = 0.0f;
+	if(Input.GetKey(";")) yaw = keyRotSensitivity;
+	if(Input.GetKey("k")) yaw = -keyRotSensitivity;
+	yaw += Input.GetAxis("Mouse X") * mouseSensitivity;
+	yaw += Input.GetAxis("RightStickX") * joyRotSensitivity;
+	transform.Rotate(Vector3.up * yaw);
+	
+	if(Input.GetKey("o")) cameraPitch += keyRotSensitivity;
+	if(Input.GetKey("l")) cameraPitch -= keyRotSensitivity;
+	cameraPitch += Input.GetAxis("Mouse Y") * mouseSensitivity;
+	cameraPitch += Input.GetAxis("RightStickY") * joyRotSensitivity;
+	cameraPitch = Mathf.Clamp(cameraPitch, -85.0f, 85.0f);
+	playerCamera.localEulerAngles = Vector3.right * cameraPitch;	
+    }
+    
+    void UpdateMovement()
+    {
+        float vTOL = 0.0f;
+        if(Input.GetKey("e")) vTOL = 1;
+	if(Input.GetKey("q")) vTOL = -1;
+	float strafe = 0.0f;
+	if(Input.GetKey("d")) strafe = 1;
+	if(Input.GetKey("a")) strafe = -1;
+	float forward = 0.0f;
+	if(Input.GetKey("w")) forward = 1;
+	if(Input.GetKey("s")) forward = -1;
+	Vector2 keySlew = new Vector2(strafe, forward);
+	keySlew.Normalize();
+        Vector2 iDir = new Vector2(Input.GetAxis("Horizontal") * joyWalkSpeed + keySlew.x, Input.GetAxis("Vertical") * joyWalkSpeed + keySlew.y);
+	vTOL += Input.GetAxis("RightTrigger") * joyFlySpeed; //axis 6
+	vTOL -= Input.GetAxis("LeftTrigger") * joyFlySpeed; //axis 3
+	
+	Vector3 velocity = (transform.forward * iDir.y + transform.right * iDir.x) * walkSpeed + transform.up * vTOL * vertSpeed;
+	
+	controller.Move(velocity * Time.deltaTime);
+    }
+
+}

--- a/script/build_unity_project.md
+++ b/script/build_unity_project.md
@@ -23,4 +23,9 @@
 - In the Hierarchy pane, select the player. Then drag the child Camera into the PlayerCamera slot in the PlayerController script properties (which probably says ```Transform None``` at the moment) in the Inspector. This links the camera to the corresponding object in the script (and is easy to forget, which will cause the controls to not work).
 - You should be able to press the play button at the top of the editor screen and try it now. To exit play mode, press the play button again (there's no stop button, and the pause button doesn't exit play mode). 
 
+## Lighting
+The single-point lighting that seems to be the default in Unity leaves nasty shadows in the scene. Global illumination would be better, presumably. However, it seems as though this makes it tricky to build for WebGL. To be investigated. 
+
 # Build for WebGL
+- Select ```File``` -> ```Build Settings```, select WebGL, and press ```Switch Platform```. That takes some time as Unity pre-processes a bunch of stuff.
+- Push the Build button?

--- a/script/build_unity_project.md
+++ b/script/build_unity_project.md
@@ -8,15 +8,19 @@
 - Open your file explorer, and in the Unity directory, go to the ```Assets``` subdirectory. In it, create a directory called ```odm_mesh```.
 - Drop the entire ```odm_textured_model``` directory in there, _including the .obj file with the y-axis facing up_.
 - Head back to the Unity editor, which will proceed to import the model (takes a few minutes).
-- Drag the .obj file into the Hierarchy window on the upper left (in the Sample Scene).
+- Drag the .obj file into the Hierarchy window on the upper left (in the Sample Scene). It should appear in the Scene tab.
 
 ## Add the First-Person Character Controller
-Nice video that gives a lot of the process [here](https://www.youtube.com/watch?v=Gxmx69QVuRY)
-- Go to Unity Asset Store. In the ```Window``` menu there's a link to the Unity Asset Store, which anyway opens in a web browser (it's also [here](https://assetstore.unity.com/)). You have to be signed in to a Unity account to make this work, but presumably you have an account that you created in order to install the Unity Hub; let's hope you remember the password.
-- Grab the Standard Assets (as of time of writing, they're called _Standard Assets for Unity 2018.4_). You can't download them directly, you click a link ```Open in Unity``` and, if all goes well, return to the Unity editor and download them via the Package Manager.
-- After downloading the Standard Assets, you need to import them. You only actually need to import the FPS Controller and Utility sections, but I don't think it does a great deal of harm to import everything (maybe it makes your eventual builds bigger, but not obviously from what I can see). 
-- [Fix the compiler errors](/script/fix_standard_asset_compiler_errors.md) which will otherwise prevent you from using the Standard Assets.
-- In the ```Project``` window, go to ```Assets```, ```Standard Assets```, ```Characters```, ```FirstPersonCharacter```, ```Prefabs```, and you'll find an object called an FPSController. Drop that FPSController into the Hierarchy window.
-- In the Hierarchy window, expand the FPSController arrow, and click the FirstPersonCharacter icon.
+- In the ```GameObject``` menu, choose ```Create Empty```. Name it "player."
+- Select the player in the Hierarchy tab, and in the Inspector tab, press ```Add Component```. Search for ```Character Controller``` and add it. You should now see a wireframe Minion-shaped capsule appear in the Scene tab.
+- Click back on the player in the Hierarchy tab, right-click, and select ```Camera```. A new mini-window should appear showing the view from the camera, which will be from the point of view of the player capsule (if your mesh is positioned in view of the camera, you'll see it, otherwise it'll just show a blue sky and grey-brown blank ground).
+- Right-click on the ```Main Camera``` object in the Heirarchy pane, and delete it. We don't need it since we have a camera on the player.
+- With the camera selected, set the Y position in the Inspector to 1 (that'll just put the camera at the top of the capsule, which will make sense for a human-esque point of view).
 
+### Add a script to control the player and camera
+- In the Assets directory of this repo, there's a script called ```PlayerController.cs```. In your file explorer, copy this script into the Assets directory of the project. When you return to the Unity editor, it will proceed to import the script.
+- Select the player object in the Hierarchy pane. Drag the PlayerController script from the Assets pane into the lower part of the Inspector pane, which should have the effect of attaching the script to the player (whenever selecting the player, you'll now see the PlayerController script's properties in the Inspector pane, below the Character Controller component).
+- In the Hierarchy pane, select the player. Then drag the child Camera into the PlayerCamera slot in the PlayerController script properties (which probably says ```Transform None``` at the moment) in the Inspector. This links the camera to the corresponding object in the script (and is easy to forget, which will cause the controls to not work).
+- You should be able to press the play button at the top of the editor screen and try it now. To exit play mode, press the play button again (there's no stop button, and the pause button doesn't exit play mode). 
 
+# Build for WebGL

--- a/script/build_unity_project.md
+++ b/script/build_unity_project.md
@@ -28,4 +28,10 @@ The single-point lighting that seems to be the default in Unity leaves nasty sha
 
 # Build for WebGL
 - Select ```File``` -> ```Build Settings```, select WebGL, and press ```Switch Platform```. That takes some time as Unity pre-processes a bunch of stuff.
-- Push the Build button?
+- You'll need to disable compression on the build; for some reason the compression causes the WebGL app to load to 90% and stop.
+  - In the Build Settings pane, push the ```Player Settings...``` button on the lower left. Select ```Player``` along the left, and set ```Compression Format``` to Disabled.
+- Push the Build button. If you're on Linux and encounter a failure, it might be the library issue in the Gotchas section of the [Unity setup](/script/unity_setup) instructions.
+- If it works, it'll output a folder containing an index.html file and a couple of folders full of data. That's what you'll stick on a Web server somewhere.
+  - To test it locally, ```cd``` into the folder, and start a tiny local webserver with ```python3 -m http.server --cgi 8360```. Then in your browser type the address ```http://localhost:8360/index.html```.
+## Deploy
+- Get a server and a domain name, set up the nameservers, install Nginx, set up SSL with LetsEncrypt, stick the index.html file and data folders in the www data directory.

--- a/script/fix_standard_asset_compiler_errors.md
+++ b/script/fix_standard_asset_compiler_errors.md
@@ -1,5 +1,0 @@
-  - The Unity Standard Assets have apparently been abandoned, and are now broken. However, someone has posted a fix. [Here's the Youtube video where I found it](https://www.youtube.com/watch?v=Lzpeez_kdis&t=0s)/
-- Go to [this github page](https://github.com/johnathanhales/UnityStandardAssetFixes), and download the files ```FPSCounter.cs```, ```ForcedReset.cs```, and ```SimpleActivatorMenu.cs```.
-- You should probably exit Unity before the next step. Maybe it's fine, up to you if you want to try it while running.
-- In your file explorer, drop those three scripts into ```/path/to/project/Assets/Standard Assets/Utility``` directory. It'll ask if you want to overwrite the originals. You do.
-- Restart Unity, and the Standard Assets FPSController now works.

--- a/script/unity_setup.md
+++ b/script/unity_setup.md
@@ -2,9 +2,7 @@
 
 ## On Ubuntu 20.04
 - Download the UnityHub.appimage installer [from here](https://unity3d.com/get-unity/download), make it executable with ```sudo chmod +x UnityHub.AppImage```, and run it (```./UnityHub.appimage```). If you don't have a Unity account you'll have to create one to manage the only moderately unpleasant license procedure. [Instructions here](https://docs.unity3d.com/Manual/GettingStartedInstallingHub.html) from the official Unity documentation.
-- From within the Unity Hub, assuming you've gotten it running, create an editor Install. You might as well go for the latest Long-Term Support (LTS) version, which as of now is 2020.3. It gives you a selection of modules; I've installed the Linux, Mac, Windows, and Android frameworks so I can build running games for all of the above.
+- From within the Unity Hub, assuming you've gotten it running, create an editor Install. You might as well go for the latest Long-Term Support (LTS) version, which as of now is 2020.3. It gives you a selection of modules; I've installed the Linux, Mac, Windows, WebGL, and Android frameworks so I can build running games for all of the above.
 - Start a new project. Choose the 3D template. Put the project directory somewhere sensible (it defaults to your home directory).
 
 That should do it. Assuming this all worked, you now have an fresh, empty Unity project based on the 3D template. Now [head to the next step, wherein you'll build a Unity project containing the mesh from OpenDroneMap](/script/build_unity_project.md).
-
-There's a further snag coming up, when the Standard Assets package doesn't work with the current release of Unity, but the fix is documented in the instructions coming up next!

--- a/script/unity_setup.md
+++ b/script/unity_setup.md
@@ -6,3 +6,6 @@
 - Start a new project. Choose the 3D template. Put the project directory somewhere sensible (it defaults to your home directory).
 
 That should do it. Assuming this all worked, you now have an fresh, empty Unity project based on the 3D template. Now [head to the next step, wherein you'll build a Unity project containing the mesh from OpenDroneMap](/script/build_unity_project.md).
+
+## Gotchas
+You might encounter an error trying to build WebGL projects on Linux. [Here](https://forum.unity.com/threads/cant-build-webgl-because-of-il2cpp-suddenly-crashes-on-ubuntu-19-04.764123/) is a link to a discussion of that. In my case it was solved with ```sudo apt install libtinfo5```. 


### PR DESCRIPTION
Pretty heavy reorientation. Completely did away with the standard assets requirement, which provided a ready-build CharacterController but came with a lot of dependency hassles.

Also managed to get a WebGL build working, so threw that in.